### PR TITLE
fix URL to source

### DIFF
--- a/inst/rmarkdown/templates/html/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/html/skeleton/skeleton.Rmd
@@ -223,7 +223,7 @@ There are a few other things in Tufte CSS that we have not mentioned so far. If 
 
 We hope you will enjoy the simplicity of R Markdown and this R package, and we sincerely thank the authors of the Tufte-CSS and Tufte-LaTeX projects for developing the beautiful CSS and LaTeX classes. Our **tufte** package would not have been possible without their heavy lifting.
 
-To see the R Markdown source of this example document, you may follow [this link to Github](https://github.com/rstudio/tufte/raw/master/inst/rmarkdown/templates/tufte_html/skeleton/skeleton.Rmd), use the wizard in RStudio IDE (`File -> New File -> R Markdown -> From Template`), or open the Rmd file in the package:
+To see the R Markdown source of this example document, you may follow [this link to Github](https://raw.githubusercontent.com/eddelbuettel/tint/master/inst/rmarkdown/templates/html/skeleton/skeleton.Rmd), use the wizard in RStudio IDE (`File -> New File -> R Markdown -> From Template`), or open the Rmd file in the package:
 
 ```{r eval=FALSE}
 file.edit(


### PR DESCRIPTION
Also, I think it could be helpful to users to add this example YAML into this doc to complement the example you have for the `tufte` pkg:

```
---
title: "An Example Using the Tufte Style"
author: "John Smith"
output:
  tint::tintHtml: 
     self_contained: TRUE
---
```

This YAML is what I was looking for when I noticed that the URL to the Rmd source was wrong. What do you think?