### PR TITLE
Update URLs in documentation:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2018-11-24 Jonathan Gilligan <jonathan.gilligan@gmail.com>
+
+    * R/html.R: Fixed obsolete URL.
+    * inst/examples/simpleHtml.Rmd: Idem
+    * inst/examples/simplePdf.Rmd: Idem
+    * inst/rmarkdown/templates/tintBook/skeleton/skeleton.Rmd: Idem
+    * inst/rmarkdown/templates/tintHtml/skeleton/skeleton.Rmd: Idem
+    * inst/rmarkdown/templates/tintPdf/skeleton/skeleton.Rmd: Idem
+    * man/tintHtml.Rd: Idem
+    * vignettes/tintHtml.Rmd: Idem
+    * vignettes/tintPdf.Rmd: Item
+
 2018-11-22  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION: Addded new co-author, rolled version and date

--- a/R/html.R
+++ b/R/html.R
@@ -17,7 +17,7 @@
 #'
 #' @details \code{tintHtml} provides the HTML format based on the Tufte CSS
 #'   \url{https://edwardtufte.github.io/tufte-css/} with fonts set according to
-#' \url{http://nogginfuel.com/envisioned-css/}. 
+#' \url{https://github.com/nogginfuel/envisioned-css}. 
 #' \code{tintPdf} provides a similar PDF format using the same font family and 
 #' styling applied to the Tufte-LaTeX 
 #' \url{https://tufte-latex.github.io/tufte-latex/} class. 

--- a/inst/examples/simpleHtml.Rmd
+++ b/inst/examples/simpleHtml.Rmd
@@ -18,7 +18,7 @@ options(htmltools.dir.version = FALSE)
 [tint](http://github.com/eddelbuettel/tint) is straightforward mix of the (html and pdf
 parts of the) excellent [tufte](https://github.com/rstudio/tufte) package by JJ and Yihui,
 mixed with the [Roboto Condensed](https://fonts.google.com/specimen/Roboto+Condensed) font
-use and color scheme proposed by [envisioned css](http://nogginfuel.com/envisioned-css/)
+use and color scheme proposed by [envisioned css](https://github.com/nogginfuel/envisioned-css)
 plus minor style changes such as removal of _italics_---but otherwise true to the
 wonderful [tufte](https://github.com/rstudio/tufte) package for R---all baked together
 into a small package providing another template.

--- a/inst/examples/simplePdf.Rmd
+++ b/inst/examples/simplePdf.Rmd
@@ -18,7 +18,7 @@ options(htmltools.dir.version = FALSE)
 [tint](http://github.com/eddelbuettel/tint) is straightforward mix of the (html and pdf
 parts of the) excellent [tufte](https://github.com/rstudio/tufte) package by JJ and Yihui,
 mixed with the [Roboto Condensed](https://fonts.google.com/specimen/Roboto+Condensed) font
-use and color scheme proposed by [envisioned css](http://nogginfuel.com/envisioned-css/)
+use and color scheme proposed by [envisioned css](https://github.com/nogginfuel/envisioned-css)
 plus minor style changes such as removal of _italics_---but otherwise true to the
 wonderful [tufte](https://github.com/rstudio/tufte) package for R---all baked together
 into a small package providing another template.

--- a/inst/rmarkdown/templates/tintBook/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/tintBook/skeleton/skeleton.Rmd
@@ -25,7 +25,7 @@ ggplot(mtcars, aes(wt, mpg)) + geom_point(size=3, aes(colour=factor(cyl))) + the
 [tint](http://github.com/eddelbuettel/tint) is straightforward mix of the (html and pdf
 parts of the) excellent [tufte](https://github.com/rstudio/tufte) package by JJ and Yihui,
 mixed with the [Roboto Condensed](https://fonts.google.com/specimen/Roboto+Condensed) font
-use and color scheme proposed by [envisioned css](http://nogginfuel.com/envisioned-css/)
+use and color scheme proposed by [envisioned css](https://github.com/nogginfuel/envisioned-css)
 plus minor style changes such as removal of _italics_---but otherwise true to the
 wonderful [tufte](https://github.com/rstudio/tufte) package for R---all baked together
 into a small package providing another template.
@@ -68,7 +68,7 @@ If you have any feature requests or find bugs in **tufte**, please do not hesita
 
 This style provides first and second-level headings (that is, `#` and `##`), demonstrated in the next section. You may get unexpected output if you try to use `###` and smaller headings.
 
-`r newthought('In his later books')`^[[Beautiful Evidence](http://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
+`r newthought('In his later books')`^[[Beautiful Evidence](https://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
 
 # Figures
 

--- a/inst/rmarkdown/templates/tintHtml/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/tintHtml/skeleton/skeleton.Rmd
@@ -25,7 +25,7 @@ ggplot(mtcars, aes(wt, mpg)) + geom_point(size=3, aes(colour=factor(cyl))) + the
 [tint](http://github.com/eddelbuettel/tint) is straightforward mix of the (html and pdf
 parts of the) excellent [tufte](https://github.com/rstudio/tufte) package by JJ and Yihui,
 mixed with the [Roboto Condensed](https://fonts.google.com/specimen/Roboto+Condensed) font
-use and color scheme proposed by [envisioned css](http://nogginfuel.com/envisioned-css/)
+use and color scheme proposed by [envisioned css](https://github.com/nogginfuel/envisioned-css)
 plus minor style changes such as removal of _italics_---but otherwise true to the
 wonderful [tufte](https://github.com/rstudio/tufte) package for R---all baked together
 into a small package providing another template.
@@ -61,7 +61,7 @@ If you have any feature requests or find bugs in **tufte**, please do not hesita
 
 This style provides first and second-level headings (that is, `#` and `##`), demonstrated in the next section. You may get unexpected output if you try to use `###` and smaller headings.
 
-`r newthought('In his later books')`^[[Beautiful Evidence](http://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
+`r newthought('In his later books')`^[[Beautiful Evidence](https://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
 
 # Figures
 

--- a/inst/rmarkdown/templates/tintPdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/tintPdf/skeleton/skeleton.Rmd
@@ -25,7 +25,7 @@ ggplot(mtcars, aes(wt, mpg)) + geom_point(size=3, aes(colour=factor(cyl))) + the
 [tint](http://github.com/eddelbuettel/tint) is straightforward mix of the (html and pdf
 parts of the) excellent [tufte](https://github.com/rstudio/tufte) package by JJ and Yihui,
 mixed with the [Roboto Condensed](https://fonts.google.com/specimen/Roboto+Condensed) font
-use and color scheme proposed by [envisioned css](http://nogginfuel.com/envisioned-css/)
+use and color scheme proposed by [envisioned css](https://github.com/nogginfuel/envisioned-css)
 plus minor style changes such as removal of _italics_---but otherwise true to the
 wonderful [tufte](https://github.com/rstudio/tufte) package for R---all baked together
 into a small package providing another template.
@@ -61,7 +61,7 @@ If you have any feature requests or find bugs in **tufte**, please do not hesita
 
 This style provides first and second-level headings (that is, `#` and `##`), demonstrated in the next section. You may get unexpected output if you try to use `###` and smaller headings.
 
-`r newthought('In his later books')`^[[Beautiful Evidence](http://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
+`r newthought('In his later books')`^[[Beautiful Evidence](https://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
 
 # Figures
 

--- a/man/tintHtml.Rd
+++ b/man/tintHtml.Rd
@@ -73,7 +73,7 @@ Richard Feynman, but with an updated font choice.
 \details{
 \code{tintHtml} provides the HTML format based on the Tufte CSS
   \url{https://edwardtufte.github.io/tufte-css/} with fonts set according to
-\url{http://nogginfuel.com/envisioned-css/}. 
+\url{https://github.com/nogginfuel/envisioned-css}. 
 \code{tintPdf} provides a similar PDF format using the same font family and 
 styling applied to the Tufte-LaTeX 
 \url{https://tufte-latex.github.io/tufte-latex/} class. 

--- a/vignettes/tintHTML.Rmd
+++ b/vignettes/tintHTML.Rmd
@@ -32,7 +32,7 @@ ggplot(mtcars, aes(wt, mpg)) + geom_point(size=3, aes(colour=factor(cyl))) + the
 [tint](http://github.com/eddelbuettel/tint) is straightforward mix of the (html and pdf
 parts of the) excellent [tufte](https://github.com/rstudio/tufte) package by JJ and Yihui,
 mixed with the [Roboto Condensed](https://fonts.google.com/specimen/Roboto+Condensed) font
-use and color scheme proposed by [envisioned css](http://nogginfuel.com/envisioned-css/)
+use and color scheme proposed by [envisioned css](https://github.com/nogginfuel/envisioned-css)
 plus minor style changes such as removal of _italics_---but otherwise true to the
 wonderful [tufte](https://github.com/rstudio/tufte) package for R---all baked together
 into a small package providing another template.
@@ -70,7 +70,7 @@ If you have any feature requests or find bugs in **tufte**, please do not hesita
 
 This style provides first and second-level headings (that is, `#` and `##`), demonstrated in the next section. You may get unexpected output if you try to use `###` and smaller headings.
 
-`r newthought('In his later books')`^[[Beautiful Evidence](http://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
+`r newthought('In his later books')`^[[Beautiful Evidence](https://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
 
 # Figures
 

--- a/vignettes/tintPDF.Rmd
+++ b/vignettes/tintPDF.Rmd
@@ -32,7 +32,7 @@ ggplot(mtcars, aes(wt, mpg)) + geom_point(size=3, aes(colour=factor(cyl))) + the
 [tint](http://github.com/eddelbuettel/tint) is straightforward mix of the (html and pdf
 parts of the) excellent [tufte](https://github.com/rstudio/tufte) package by JJ and Yihui,
 mixed with the [Roboto Condensed](https://fonts.google.com/specimen/Roboto+Condensed) font
-use and color scheme proposed by [envisioned css](http://nogginfuel.com/envisioned-css/)
+use and color scheme proposed by [envisioned css](https://github.com/nogginfuel/envisioned-css)
 plus minor style changes such as removal of _italics_---but otherwise true to the
 wonderful [tufte](https://github.com/rstudio/tufte) package for R---all baked together
 into a small package providing another template.
@@ -70,7 +70,7 @@ If you have any feature requests or find bugs in **tufte**, please do not hesita
 
 This style provides first and second-level headings (that is, `#` and `##`), demonstrated in the next section. You may get unexpected output if you try to use `###` and smaller headings.
 
-`r newthought('In his later books')`^[[Beautiful Evidence](http://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
+`r newthought('In his later books')`^[[Beautiful Evidence](https://www.edwardtufte.com/tufte/books_be)], Tufte starts each section with a bit of vertical space, a non-indented paragraph, and sets the first few words of the sentence in small caps. To accomplish this using this style, call the `newthought()` function in **tufte** in an _inline R expression_ `` `r ` `` as demonstrated at the beginning of this paragraph.^[Note you should not assume **tufte** has been attached to your R session. You should either `library(tufte)` in your R Markdown document before you call `newthought()`, or use `tint::newthought()`.]
 
 # Figures
 


### PR DESCRIPTION
A very minor housekeeping PR. A number of files that are not checked by CRAN and `R CMD check --as-cran` have broken or out-of-date URLs. I've edited the documentation (various .Rmd files and Roxygen comments in R/html.R) to these:

* Replace broken "http://nogginfuel.com/envisioned-css" with working "https://github.com/nogginfuel/envisioned-css"

* Replace "http://www.edwardtufte.com" with "https://www.edwardtufte.com" because the site has set a 301 redirect to the `https:` version ([CRAN says](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#DOCF82) that some major Linux and MacOS releases as of 2017 had trouble with redirects to https.).

All of this passes `R CMD check --as-cran` with `_R_CRAN_CHECK_INCOMING` and `_R_CRAN_CHECK_INCOMING_REMOTE` set to `TRUE` with no errors, warnings, or notes and it builds successfully with Travis-CI. I've manually checked the changed URLs in a browser to make sure they work.