### PR TITLE
Style bibliography (when link-citations: false)

### DIFF
--- a/inst/rmarkdown/templates/tintHtml/resources/tint.css
+++ b/inst/rmarkdown/templates/tintHtml/resources/tint.css
@@ -214,10 +214,11 @@ img {max-width: 100%;}
                          left: 0.1rem; }
 
 .csl-bib-body { width: 55%;
-                margin-top: 1.4rem; }
+                margin-top: 1.0rem;
+                margin-bottom: 3.0rem; }
 
 .csl-entry { margin: .75rem 0 .75rem;
-             line-height: 1.5; }
+             line-height: 1.25; }
 
 p, footer, table { width: 55%; }
 table table, li p, li pre { width: auto; }
@@ -235,7 +236,7 @@ div.fullwidth p.caption {
 
 p.caption { text-align: left; }
 
-@media screen and (max-width: 760px) { p, footer, ol, ul, table, .csl-bib-body { width: 90%; }
+@media screen and (max-width: 760px) { p, footer, ol, ul, table, { width: 90%; }
                                        pre { width: 87.5%; }
                                        ul { width: 85%; }
                                        figure { max-width: 90%; }

--- a/inst/rmarkdown/templates/tintHtml/resources/tint.css
+++ b/inst/rmarkdown/templates/tintHtml/resources/tint.css
@@ -213,6 +213,12 @@ img {max-width: 100%;}
                          top: -0.5rem;
                          left: 0.1rem; }
 
+.csl-bib-body { width: 55%;
+                margin-top: 1.4rem; }
+
+.csl-entry { margin: .75rem 0 .75rem;
+             line-height: 1.5; }
+
 p, footer, table { width: 55%; }
 table table, li p, li pre { width: auto; }
 li p, li pre {margin-top: auto; }
@@ -229,7 +235,7 @@ div.fullwidth p.caption {
 
 p.caption { text-align: left; }
 
-@media screen and (max-width: 760px) { p, footer, ol, ul, table { width: 90%; }
+@media screen and (max-width: 760px) { p, footer, ol, ul, table, .csl-bib-body { width: 90%; }
                                        pre { width: 87.5%; }
                                        ul { width: 85%; }
                                        figure { max-width: 90%; }


### PR DESCRIPTION
I didn't like the look of the references section if I had `link-citations: false` in the YAML and `output: tint::tintHtml` i.e. when references appear at the end of the document rather than as sidenotes. The entries were too close together with inadequate line spacing. This PR tweaks the CSS slightly so the references look a little bit nicer - that's all.